### PR TITLE
Implement tasks assign command

### DIFF
--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -78,11 +78,11 @@ Format: `contacts delete INDEX`
 
 ==== Assign tasks to contact: `contacts assign`
 
-Format: `contacts assign CONTACT_INDEX... TASK_INDEX..`
+Format: `contacts assign c/CONTACT_INDEX k/TASK_INDEX`
 
 ==== Unassign tasks from contact: `contacts unassign`
 
-Format: `contacts unassign CONTACT_INDEX... (TASK_INDEX...|*)`
+Format: `contacts unassign c/CONTACT_INDEX... (k/TASK_INDEX...|*)`
 
 If `*` is provided as the argument for TASK_INDEX, unassign all tasks
 from the contacts specified.
@@ -133,11 +133,11 @@ Delete all tasks corresponding to the indices provided.
 
 ==== Assign person to task: `tasks assign`
 
-Format: `tasks assign k/TASK_INDEX... c/CONTACT_INDEX...`
+Format: `tasks assign k/TASK_INDEX c/CONTACT_INDEX`
 
 ==== Unassign person from tasks: `tasks unassign`
 
-Format: `tasks unassign k/TASK_INDEX... (c/CONTACT_INDEX...|*)`
+Format: `tasks unassign k/TASK_INDEX (c/CONTACT_INDEX...|*)`
 
 If `*` is provided as the argument for CONTACT_INDEX, all contacts will
 be unassigned.

--- a/src/main/java/seedu/address/logic/commands/contacts/AssignCommand.java
+++ b/src/main/java/seedu/address/logic/commands/contacts/AssignCommand.java
@@ -18,6 +18,7 @@ import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.PersonId;
 import seedu.address.model.task.Task;
 import seedu.address.model.task.TaskId;
 
@@ -71,9 +72,13 @@ public class AssignCommand extends Command {
         Person editedPerson = new Person(personToEdit.getId(), personToEdit.getName(), personToEdit.getPhone(),
                 personToEdit.getEmail(), personToEdit.getAddress(), personToEdit.getTags(), updatedTaskIds);
 
+        Set<PersonId> updatedPersonIds = new HashSet<>(taskToAssign.getPersonIds());
+        updatedPersonIds.add(personToEdit.getId());
+        Task editedTask = new Task(taskToAssign.getId(), taskToAssign.getName(), taskToAssign.getStartDateTime(),
+                taskToAssign.getEndDateTime(), taskToAssign.getTags(), updatedPersonIds);
+
         model.updatePerson(personToEdit, editedPerson);
-        // TODO: Check if updateFilteredPersonList call is necessary
-        // model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        model.updateTask(taskToAssign, editedTask);
         model.commitAddressBook();
 
         EventsCenter.getInstance().post(new JumpToPersonListRequestEvent(targetContactIndex));

--- a/src/main/java/seedu/address/logic/commands/tasks/AssignCommand.java
+++ b/src/main/java/seedu/address/logic/commands/tasks/AssignCommand.java
@@ -1,0 +1,97 @@
+package seedu.address.logic.commands.tasks;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.contacts.CliSyntax.PREFIX_CONTACT_ID;
+import static seedu.address.logic.parser.contacts.CliSyntax.PREFIX_TASK_ID;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import seedu.address.commons.core.EventsCenter;
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.commons.events.ui.JumpToPersonListRequestEvent;
+import seedu.address.logic.CommandHistory;
+import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.PersonId;
+import seedu.address.model.task.Task;
+import seedu.address.model.task.TaskId;
+
+/**
+ * Assigns a task to a contact. Both contact and task are identified by the index number used in the displayed person
+ * and task list respectively.
+ */
+public class AssignCommand extends Command {
+
+    public static final String COMMAND_WORD = "assign";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Assigns a task to a contact. Both contact and task are identified by the index number used in the "
+            + "displayed person and task list respectively.\n"
+            + "Parameters: "
+            + PREFIX_CONTACT_ID + "CONTACT_INDEX "
+            + PREFIX_TASK_ID + "TASK_INDEX\n"
+            + "Example: " + COMMAND_WORD + " "
+            + PREFIX_CONTACT_ID + "2 "
+            + PREFIX_TASK_ID + "4";
+
+    public static final String MESSAGE_ASSIGN_TASK_SUCCESS = "Assigned Task %1$s to Person %2$s";
+
+    private final Index targetContactIndex;
+    private final Index targetTaskIndex;
+
+    public AssignCommand(Index targetContactIndex, Index targetTaskIndex) {
+        this.targetContactIndex = targetContactIndex;
+        this.targetTaskIndex = targetTaskIndex;
+    }
+
+    @Override
+    public CommandResult execute(Model model, CommandHistory history) throws CommandException {
+        requireNonNull(model);
+
+        List<Person> filteredPersonList = model.getFilteredPersonList();
+        if (targetContactIndex.getZeroBased() >= filteredPersonList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+
+        List<Task> filteredTaskList = model.getFilteredTaskList();
+        if (targetTaskIndex.getZeroBased() >= filteredTaskList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_TASK_DISPLAYED_INDEX);
+        }
+
+        Person personToEdit = filteredPersonList.get(targetContactIndex.getZeroBased());
+        Task taskToAssign = filteredTaskList.get(targetTaskIndex.getZeroBased());
+
+        Set<TaskId> updatedTaskIds = new HashSet<>(personToEdit.getTaskIds());
+        updatedTaskIds.add(taskToAssign.getId());
+        Person editedPerson = new Person(personToEdit.getId(), personToEdit.getName(), personToEdit.getPhone(),
+                personToEdit.getEmail(), personToEdit.getAddress(), personToEdit.getTags(), updatedTaskIds);
+
+        Set<PersonId> updatedPersonIds = new HashSet<>(taskToAssign.getPersonIds());
+        updatedPersonIds.add(personToEdit.getId());
+        Task editedTask = new Task(taskToAssign.getId(), taskToAssign.getName(), taskToAssign.getStartDateTime(),
+                taskToAssign.getEndDateTime(), taskToAssign.getTags(), updatedPersonIds);
+
+        model.updatePerson(personToEdit, editedPerson);
+        model.updateTask(taskToAssign, editedTask);
+        model.commitAddressBook();
+
+        EventsCenter.getInstance().post(new JumpToPersonListRequestEvent(targetContactIndex));
+        return new CommandResult(String.format(MESSAGE_ASSIGN_TASK_SUCCESS,
+                targetTaskIndex.getOneBased(), targetContactIndex.getOneBased()));
+
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof AssignCommand // instanceof handles nulls
+                && targetContactIndex.equals(((AssignCommand) other).targetContactIndex) // state checks
+                && targetTaskIndex.equals(((AssignCommand) other).targetTaskIndex)); // state checks
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/tasks/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/tasks/EditCommand.java
@@ -22,6 +22,7 @@ import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
+import seedu.address.model.person.PersonId;
 import seedu.address.model.tag.Tag;
 import seedu.address.model.task.DateTime;
 import seedu.address.model.task.Name;
@@ -100,8 +101,9 @@ public class EditCommand extends Command {
         DateTime updatedStartDateTime = editTaskDescriptor.getStartDateTime().orElse(taskToEdit.getStartDateTime());
         DateTime updatedEndDateTime = editTaskDescriptor.getEndDateTime().orElse(taskToEdit.getEndDateTime());
         Set<Tag> updatedTags = editTaskDescriptor.getTags().orElse(taskToEdit.getTags());
+        Set<PersonId> updatedPersons = taskToEdit.getPersonIds();
 
-        return new Task(id, updatedName, updatedStartDateTime, updatedEndDateTime, updatedTags);
+        return new Task(id, updatedName, updatedStartDateTime, updatedEndDateTime, updatedTags, updatedPersons);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/parser/TasksParser.java
+++ b/src/main/java/seedu/address/logic/parser/TasksParser.java
@@ -9,12 +9,14 @@ import java.util.regex.Pattern;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.tasks.AddCommand;
+import seedu.address.logic.commands.tasks.AssignCommand;
 import seedu.address.logic.commands.tasks.DeleteCommand;
 import seedu.address.logic.commands.tasks.EditCommand;
 import seedu.address.logic.commands.tasks.FindCommand;
 import seedu.address.logic.commands.tasks.ListCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.logic.parser.tasks.AddCommandParser;
+import seedu.address.logic.parser.tasks.AssignCommandParser;
 import seedu.address.logic.parser.tasks.DeleteCommandParser;
 import seedu.address.logic.parser.tasks.EditCommandParser;
 import seedu.address.logic.parser.tasks.FindCommandParser;
@@ -62,6 +64,9 @@ public class TasksParser {
 
         case FindCommand.COMMAND_WORD:
             return new FindCommandParser().parse(arguments);
+
+        case AssignCommand.COMMAND_WORD:
+            return new AssignCommandParser().parse(arguments);
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/address/logic/parser/tasks/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/tasks/AddCommandParser.java
@@ -8,6 +8,7 @@ import static seedu.address.logic.parser.tasks.CliSyntax.PREFIX_START_DATE;
 import static seedu.address.logic.parser.tasks.CliSyntax.PREFIX_START_TIME;
 import static seedu.address.logic.parser.tasks.CliSyntax.PREFIX_TAG;
 
+import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -17,6 +18,7 @@ import seedu.address.logic.parser.ArgumentTokenizer;
 import seedu.address.logic.parser.Parser;
 import seedu.address.logic.parser.Prefix;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.PersonId;
 import seedu.address.model.tag.Tag;
 import seedu.address.model.task.DateTime;
 import seedu.address.model.task.Name;
@@ -52,8 +54,9 @@ public class AddCommandParser implements Parser<AddCommand> {
             throw new ParseException(Task.MESSAGE_START_AFTER_END);
         }
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
+        Set<PersonId> personIds = new HashSet<>();
 
-        Task task = new Task(null, name, startDateTime, endDateTime, tagList);
+        Task task = new Task(null, name, startDateTime, endDateTime, tagList, personIds);
 
         return new AddCommand(task);
     }

--- a/src/main/java/seedu/address/logic/parser/tasks/AssignCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/tasks/AssignCommandParser.java
@@ -1,4 +1,4 @@
-package seedu.address.logic.parser.contacts;
+package seedu.address.logic.parser.tasks;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.contacts.CliSyntax.PREFIX_CONTACT_ID;
@@ -7,7 +7,7 @@ import static seedu.address.logic.parser.contacts.CliSyntax.PREFIX_TASK_ID;
 import java.util.stream.Stream;
 
 import seedu.address.commons.core.index.Index;
-import seedu.address.logic.commands.contacts.AssignCommand;
+import seedu.address.logic.commands.tasks.AssignCommand;
 import seedu.address.logic.parser.ArgumentMultimap;
 import seedu.address.logic.parser.ArgumentTokenizer;
 import seedu.address.logic.parser.Parser;
@@ -46,4 +46,3 @@ public class AssignCommandParser implements Parser<AssignCommand> {
         return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
 }
-

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -75,7 +75,7 @@ public class Person {
     }
 
     /**
-     * Returns an immutable tag set, which throws {@code UnsupportedOperationException}
+     * Returns an immutable task ID set, which throws {@code UnsupportedOperationException}
      * if modification is attempted.
      */
     public Set<TaskId> getTaskIds() {
@@ -135,7 +135,7 @@ public class Person {
                 .append(getAddress())
                 .append(" Tags: ");
         getTags().forEach(builder::append);
-        builder.append(" TasksIds: ");
+        builder.append(" TaskIds: ");
         getTaskIds().forEach(builder::append);
         return builder.toString();
     }

--- a/src/main/java/seedu/address/model/task/Task.java
+++ b/src/main/java/seedu/address/model/task/Task.java
@@ -7,6 +7,7 @@ import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
 
+import seedu.address.model.person.PersonId;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -23,12 +24,14 @@ public class Task {
     private final DateTime startDateTime;
     private final DateTime endDateTime;
     private final Set<Tag> tags = new HashSet<>();
+    private final Set<PersonId> personIds = new HashSet<>();
 
     /**
      * Every field must be present and not null.
      */
-    public Task(TaskId id, Name name, DateTime startDateTime, DateTime endDateTime, Set<Tag> tags) {
-        requireAllNonNull(name, startDateTime, endDateTime, tags);
+    public Task(TaskId id, Name name, DateTime startDateTime, DateTime endDateTime,
+                Set<Tag> tags, Set<PersonId> personIds) {
+        requireAllNonNull(name, startDateTime, endDateTime, tags, personIds);
         if (id != null) {
             this.id = id;
         } else {
@@ -38,6 +41,7 @@ public class Task {
         this.startDateTime = startDateTime;
         this.endDateTime = endDateTime;
         this.tags.addAll(tags);
+        this.personIds.addAll(personIds);
     }
 
     public TaskId getId() {
@@ -62,6 +66,14 @@ public class Task {
      */
     public Set<Tag> getTags() {
         return Collections.unmodifiableSet(tags);
+    }
+
+    /**
+     * Returns an immutable person ID set, which throws {@code UnsupportedOperationException}
+     * if modification is attempted.
+     */
+    public Set<PersonId> getPersonIds() {
+        return Collections.unmodifiableSet(personIds);
     }
 
     /**
@@ -120,6 +132,8 @@ public class Task {
                 .append(getEndDateTime().getTime())
                 .append(" Tags: ");
         getTags().forEach(builder::append);
+        builder.append(" PersonIds: ");
+        getPersonIds().forEach(builder::append);
         return builder.toString();
     }
 

--- a/src/main/java/seedu/address/storage/XmlAdaptedPersonId.java
+++ b/src/main/java/seedu/address/storage/XmlAdaptedPersonId.java
@@ -1,0 +1,59 @@
+package seedu.address.storage;
+
+import javax.xml.bind.annotation.XmlValue;
+
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.person.PersonId;
+
+/**
+ * JAXB-friendly adapted version of the PersonId.
+ */
+public class XmlAdaptedPersonId {
+
+    @XmlValue
+    private String personIdStr;
+
+    /**
+     * Constructs an XmlAdaptedPersonId.
+     * This is the no-arg constructor that is required by JAXB.
+     */
+    public XmlAdaptedPersonId() {}
+
+    /**
+     * Constructs a {@code XmlAdaptedPersonId} with the given {@code personIdStr}.
+     */
+    public XmlAdaptedPersonId(String personIdStr) {
+        this.personIdStr = personIdStr;
+    }
+
+    /**
+     * Converts a given PersonId into this class for JAXB use.
+     *
+     * @param source future changes to this will not affect the created
+     */
+    public XmlAdaptedPersonId(PersonId source) {
+        personIdStr = source.id;
+    }
+
+    /**
+     * Converts this jaxb-friendly adapted tag object into the model's PersonId object.
+     *
+     * @throws IllegalValueException if there were any data constraints violated in the adapted person
+     */
+    public PersonId toModelType() throws IllegalValueException {
+        return new PersonId(personIdStr);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof XmlAdaptedPersonId)) {
+            return false;
+        }
+
+        return personIdStr.equals(((XmlAdaptedPersonId) other).personIdStr);
+    }
+}

--- a/src/main/java/seedu/address/storage/XmlAdaptedTask.java
+++ b/src/main/java/seedu/address/storage/XmlAdaptedTask.java
@@ -11,6 +11,7 @@ import java.util.stream.Collectors;
 import javax.xml.bind.annotation.XmlElement;
 
 import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.person.PersonId;
 import seedu.address.model.tag.Tag;
 import seedu.address.model.task.DateTime;
 import seedu.address.model.task.Name;
@@ -36,6 +37,8 @@ public class XmlAdaptedTask {
 
     @XmlElement
     private List<XmlAdaptedTag> tagged = new ArrayList<>();
+    @XmlElement
+    private List<XmlAdaptedPersonId> assigned = new ArrayList<>();
 
     /**
      * Constructs an XmlAdaptedTask.
@@ -48,13 +51,16 @@ public class XmlAdaptedTask {
      * Constructs an {@code XmlAdaptedTask} with the given task details.
      */
     public XmlAdaptedTask(String id, String name, DateTime startDateTime, DateTime endDateTime,
-                          List<XmlAdaptedTag> tagged) {
+                          List<XmlAdaptedTag> tagged, List<XmlAdaptedPersonId> assigned) {
         this.id = id;
         this.name = name;
         this.startDateTime = startDateTime.getCalendar();
         this.endDateTime = endDateTime.getCalendar();
         if (tagged != null) {
             this.tagged = new ArrayList<>(tagged);
+        }
+        if (assigned != null) {
+            this.assigned = new ArrayList<>(assigned);
         }
     }
 
@@ -71,6 +77,9 @@ public class XmlAdaptedTask {
         tagged = source.getTags().stream()
                 .map(XmlAdaptedTag::new)
                 .collect(Collectors.toList());
+        assigned = source.getPersonIds().stream()
+                  .map(XmlAdaptedPersonId::new)
+                  .collect(Collectors.toList());
     }
 
     /**
@@ -82,6 +91,11 @@ public class XmlAdaptedTask {
         final List<Tag> taskTags = new ArrayList<>();
         for (XmlAdaptedTag tag : tagged) {
             taskTags.add(tag.toModelType());
+        }
+
+        final List<PersonId> taskPersonIds = new ArrayList<>();
+        for (XmlAdaptedPersonId personId : assigned) {
+            taskPersonIds.add(personId.toModelType());
         }
 
         if (id == null) {
@@ -106,7 +120,8 @@ public class XmlAdaptedTask {
         final DateTime modelEndDateTime = new DateTime(endDateTime);
 
         final Set<Tag> modelTags = new HashSet<>(taskTags);
-        return new Task(modelId, modelName, modelStartDateTime, modelEndDateTime, modelTags);
+        final Set<PersonId> modelPersonIds = new HashSet<>(taskPersonIds);
+        return new Task(modelId, modelName, modelStartDateTime, modelEndDateTime, modelTags, modelPersonIds);
     }
 
     @Override
@@ -124,6 +139,7 @@ public class XmlAdaptedTask {
                 && Objects.equals(name, otherPerson.name)
                 && Objects.equals(startDateTime, otherPerson.startDateTime)
                 && Objects.equals(endDateTime, otherPerson.endDateTime)
-                && tagged.equals(otherPerson.tagged);
+                && tagged.equals(otherPerson.tagged)
+                && assigned.equals(otherPerson.assigned);
     }
 }


### PR DESCRIPTION
Resolves #23 and #43.

Implements the `tasks assign` command and modifies `contacts assign`, making both create 2-way assignments by storing task IDs in contacts, and contact IDs in the task.