### PR TITLE
Fix NullPointerException on tasks edit

### DIFF
--- a/src/main/java/seedu/address/logic/commands/tasks/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/tasks/AddCommand.java
@@ -7,6 +7,7 @@ import static seedu.address.logic.parser.tasks.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.tasks.CliSyntax.PREFIX_START_DATE;
 import static seedu.address.logic.parser.tasks.CliSyntax.PREFIX_START_TIME;
 import static seedu.address.logic.parser.tasks.CliSyntax.PREFIX_TAG;
+import static seedu.address.model.task.Task.MESSAGE_START_AFTER_END;
 
 import seedu.address.logic.CommandHistory;
 import seedu.address.logic.commands.Command;
@@ -55,6 +56,10 @@ public class AddCommand extends Command {
     @Override
     public CommandResult execute(Model model, CommandHistory history) throws CommandException {
         requireNonNull(model);
+
+        if (!toAdd.isValidDateTimeRange()) {
+            throw new CommandException(MESSAGE_START_AFTER_END);
+        }
 
         if (model.hasTask(toAdd)) {
             throw new CommandException(MESSAGE_DUPLICATE_TASK);

--- a/src/main/java/seedu/address/logic/commands/tasks/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/tasks/EditCommand.java
@@ -7,6 +7,7 @@ import static seedu.address.logic.parser.tasks.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.tasks.CliSyntax.PREFIX_START_DATE;
 import static seedu.address.logic.parser.tasks.CliSyntax.PREFIX_START_TIME;
 import static seedu.address.logic.parser.tasks.CliSyntax.PREFIX_TAG;
+import static seedu.address.model.task.Task.MESSAGE_START_AFTER_END;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -80,6 +81,10 @@ public class EditCommand extends Command {
 
         Task taskToEdit = lastShownList.get(index.getZeroBased());
         Task editedTask = createEditedTask(taskToEdit, editTaskDescriptor);
+
+        if (!editedTask.isValidDateTimeRange()) {
+            throw new CommandException(MESSAGE_START_AFTER_END);
+        }
 
         if (!taskToEdit.isSameTask(editedTask) && model.hasTask(editedTask)) {
             throw new CommandException(MESSAGE_DUPLICATE_TASK);
@@ -212,10 +217,6 @@ public class EditCommand extends Command {
                     && getStartDateTime().equals(e.getStartDateTime())
                     && getEndDateTime().equals(e.getEndDateTime())
                     && getTags().equals(e.getTags());
-        }
-
-        public boolean isValidDateTimeRange() {
-            return startDateTime.compareTo(endDateTime) <= 0;
         }
     }
 }

--- a/src/main/java/seedu/address/logic/commands/tasks/SelectCommand.java
+++ b/src/main/java/seedu/address/logic/commands/tasks/SelectCommand.java
@@ -31,7 +31,9 @@ public class SelectCommand extends Command {
 
     private final Index targetIndex;
 
-    public SelectCommand(Index targetIndex) { this.targetIndex = targetIndex; }
+    public SelectCommand(Index targetIndex) {
+        this.targetIndex = targetIndex;
+    }
 
     @Override
     public CommandResult execute(Model model, CommandHistory history) throws CommandException {

--- a/src/main/java/seedu/address/logic/parser/tasks/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/tasks/AddCommandParser.java
@@ -55,9 +55,6 @@ public class AddCommandParser implements Parser<AddCommand> {
                 argMultimap.getValue(PREFIX_START_TIME).orElse(nowTimeString));
         DateTime endDateTime = ParserUtil.parseDateTime(argMultimap.getValue(PREFIX_END_DATE).get(),
                 argMultimap.getValue(PREFIX_END_TIME).get());
-        if (startDateTime.compareTo(endDateTime) > 0) {
-            throw new ParseException(Task.MESSAGE_START_AFTER_END);
-        }
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
         Set<PersonId> personIds = new HashSet<>();
 

--- a/src/main/java/seedu/address/logic/parser/tasks/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/tasks/EditCommandParser.java
@@ -25,7 +25,6 @@ import seedu.address.logic.parser.Parser;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.tag.Tag;
 import seedu.address.model.task.DateTime;
-import seedu.address.model.task.Task;
 
 /**
  * Parses input arguments and creates a new EditCommand object
@@ -69,9 +68,6 @@ public class EditCommandParser implements Parser<EditCommand> {
             DateTime endDateTime = ParserUtil.parseDateTime(argMultiMap.getValue(PREFIX_END_DATE).get(),
                     argMultiMap.getValue(PREFIX_END_TIME).get());
             editTaskDescriptor.setEndDateTime(endDateTime);
-        }
-        if (!editTaskDescriptor.isValidDateTimeRange()) {
-            throw new ParseException(Task.MESSAGE_START_AFTER_END);
         }
 
         parseTagsForEdit(argMultiMap.getAllValues(PREFIX_TAG)).ifPresent(editTaskDescriptor::setTags);

--- a/src/main/java/seedu/address/model/task/Task.java
+++ b/src/main/java/seedu/address/model/task/Task.java
@@ -137,4 +137,7 @@ public class Task {
         return builder.toString();
     }
 
+    public boolean isValidDateTimeRange() {
+        return startDateTime.compareTo(endDateTime) <= 0;
+    }
 }


### PR DESCRIPTION
Fixes #128 

On editing task, I was comparing the EditTaskDescriptor `startDateTime` and `endDateTime` which if not specified are `null`s and will result in `NullPointerException` (Java was swallowing the exceptions due to "defensive programming", refer to https://github.com/nus-cs2103-AY1819S1/forum/issues/127)

My solution is to move the `DateTime` range validation to the `Command` instead of the `Parser`. I have also changed `AddCommand` and `AddCommandParser` for the sake of consistency